### PR TITLE
chore: migrate renovate preset to LabeeHive/renovate-config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'github>labeehive/.github:default.json5',
+    'github>LabeeHive/renovate-config:default.json5',
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Background

Consolidating Renovate-related configuration to a dedicated repo. The shared preset previously hosted at `LabeeHive/.github:default.json5` has been moved to `LabeeHive/renovate-config:default.json5`.

This PR updates the preset reference. Functionality is unchanged.

## Related

- `LabeeHive/renovate-config` — new home of the shared preset
- `LabeeHive/.github` — old location (will be removed once all repos are migrated)